### PR TITLE
Add json null type

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = schemaByExample;
 
 
 const rules = [
+  [_.isNull, () => ({type: 'null'})],
   [_.isNumber, () => ({type: 'number'})],
   [_.isBoolean, () => ({type: 'boolean'})],
   [_.isString, () => ({type: 'string'})],


### PR DESCRIPTION
You may or may not want to accept this PR.
the module was throwing an error on the json I ingested. The first item in an array had a property with a null value.
In the real schema the property was  a nullable string.
